### PR TITLE
Remove requirement for AWS creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ BUILD_ENV_PATH=./env tr-server
 | SSL_KEY               | The location of the SSL key                                                          | /ssl/private.key     | OPTIONAL                         |
 | BUILD_PATH            | The location to keep the build                                                       | /build               | OPTIONAL                         |
 | S3_BUCKET             | The location of the S3 bucket holding the build                                      | _NA_                 | OPTIONAL                         |
-| AWS_ACCESS_KEY_ID     | The AWS access key needed to download from the bucket                                | _NA_                 | REQUIRED if S3_BUCKET provided   |
-| AWS_SECRET_ACCESS_KEY | The AWS secret key needed to download from the bucket                                | _NA_                 | REQUIRED if S3_BUCKET provided   |
 | WRITE_FRAGMENT_PATH   | Provide the path to where GraphQL fragments be written                               | _NA_                 | OPTIONAL                         |
 | FRAGMENTS_ROUTE       | The GraphQL route to get fragments from on BACKEND_URL                               | /graphql             | OPTIONAL                         |
 | BUILD_ENV_PATH        | A .env file to read environment variables from                                       | _NA_                 | OPTIONAL                         |
 
-- TODO image could be considerable smaller
+- TODO image could be considerably smaller

--- a/examples/example-remote.yml
+++ b/examples/example-remote.yml
@@ -8,14 +8,12 @@ services:
       # and Dockerfile
       context: ../
       dockerfile: Dockerfile
-    # Pass in AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-    env_file:
-      - aws.env.secret
     # Environment variables
     environment:
       FRONTEND_URL: ${FRONTEND_URL:-https://yo.com:3012}
       BACKEND_URL: ${BACKEND_URL:-https://app:4012}
       S3_BUCKET: ${S3_BUCKET:-dev-privacy-page-transcend-io}
+      AWS_PROFILE: ${AWS_PROFILE:-transcend-prod}
     ports:
       # Exposes 3012 from the container to the host on 3012
       - "3012:3012"
@@ -24,3 +22,5 @@ services:
       - "../server:/app/server"
       # Mount the certs
       - "../server/ssl:/ssl"
+      # Maps the local aws credentials onto the Docker filesystem
+      - "${HOME}/.aws:/root/.aws"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transcend-io/spa-static-server",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "A docker image that will run a static build of a SPA, redirecting 404 to index.html",
   "license": "MIT",
   "repository": {

--- a/server/index.js
+++ b/server/index.js
@@ -20,17 +20,10 @@ const logger = require('./logger');
 const setup = require('./middlewares');
 const getFragmentTypes = require('./getFragmentTypes');
 
-// Load in assets from s3
+// Load in assets from s3. AWS credentials are borrowed from the local ~/.aws folder
 if (envs.S3_BUCKET) {
-  // Ensure access key and secret are set
-  if (!envs.AWS_ACCESS_KEY_ID || !envs.AWS_SECRET_ACCESS_KEY) {
-    throw new Error(
-      'AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be provided with S3_BUCKET',
-    );
-  }
-
-  logger.info(`Cloning in the contents form the s3 bucket: ${envs.S3_BUCKET}"`);
-  const cmd = `AWS_ACCESS_KEY_ID=${envs.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${envs.AWS_SECRET_ACCESS_KEY} aws s3 cp s3://${envs.S3_BUCKET}/ "${envs.BUILD_PATH}" --recursive`;
+  logger.info(`Cloning in the contents from the s3 bucket: ${envs.S3_BUCKET}"`);
+  const cmd = `aws s3 cp s3://${envs.S3_BUCKET}/ "${envs.BUILD_PATH}" --recursive`;
   execSync(cmd);
 }
 


### PR DESCRIPTION
Instead of passing in AWS Creds in a secret env var file, we can mount our local `~/.aws` folder onto DOCKER.

This will be very helpful in `main`, where we want to make use of roles in AWS for devs working locally

I tested that this works with `yarn example:remote:up`